### PR TITLE
feat(1.6.8): remove .env file from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@freecodecamp/freecodecamp-os",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
   "author": "freeCodeCamp",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Package used for freeCodeCamp projects with the freeCodeCamp Courses VSCode extension",
   "scripts": {
     "start": "npm run build:client && node ./.freeCodeCamp/tooling/server.js",


### PR DESCRIPTION
I accidentally published a legacy `.env` file to npm with versions 1.6.6 and 1.6.7 - this is to remove it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
