### PR TITLE
fix(1.6.9): pass ws to reset function

### DIFF
--- a/.freeCodeCamp/tooling/reset.js
+++ b/.freeCodeCamp/tooling/reset.js
@@ -7,7 +7,7 @@ import { logover } from './logger.js';
 import { getLessonFromFile, getLessonSeed } from './parser.js';
 import { runCommand, runLessonSeed } from './seed.js';
 
-export async function resetProject() {
+export async function resetProject(ws) {
   // Get commands and handle file setting
   const { currentProject } = await getState();
   const freeCodeCampConfig = await getConfig();

--- a/.freeCodeCamp/tooling/server.js
+++ b/.freeCodeCamp/tooling/server.js
@@ -41,7 +41,7 @@ async function handleRunTests(ws, data) {
 }
 
 async function handleResetProject(ws, data) {
-  await resetProject();
+  await resetProject(ws);
   ws.send(parse({ data: { event: data.event }, event: 'RESPONSE' }));
 }
 function handleResetLesson(ws, data) {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@freecodecamp/freecodecamp-os",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
   "author": "freeCodeCamp",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Package used for freeCodeCamp projects with the freeCodeCamp Courses VSCode extension",
   "scripts": {
     "start": "npm run build:client && node ./.freeCodeCamp/tooling/server.js",


### PR DESCRIPTION
`ws` wasn't being passed to reset so it was crashing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
