### PR TITLE
fix(1.8.2): parse crlf

### DIFF
--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -57,9 +57,10 @@ export async function getProjectTitle(file) {
  */
 export async function getLessonFromFile(file, lessonNumber = 1) {
   const fileContent = await readFile(file, 'utf8');
-  const mat = fileContent.match(
+  const fileContentSansCR = fileContent.replace(/\r/g, '');
+  const mat = fileContentSansCR.match(
     new RegExp(
-      `## ${lessonNumber}\r?\n(.*?)\n## (${lessonNumber + 1}|--fcc-end--)`,
+      `## ${lessonNumber}\n(.*?)\n## (${lessonNumber + 1}|--fcc-end--)`,
       's'
     )
   );
@@ -89,8 +90,8 @@ export function getLessonDescription(lesson) {
 export function getLessonHintsAndTests(lesson) {
   const testsString = parseMarker(TEST_MARKER, lesson);
   const hintsAndTestsArr = [];
-  const hints = testsString?.match(/^(.*?)$(?=\r?\n+```js)/gm)?.filter(Boolean);
-  const tests = testsString?.match(/(?<=```js\r?\n).*?(?=```)/gms);
+  const hints = testsString?.match(/^(.*?)$(?=\n+```js)/gm)?.filter(Boolean);
+  const tests = testsString?.match(/(?<=```js\n).*?(?=```)/gms);
 
   if (hints?.length) {
     for (let i = 0; i < hints.length; i++) {
@@ -152,7 +153,7 @@ export function getAfterAll(lesson) {
  * @returns {string[]} The commands of the lesson in order
  */
 export function getCommands(seed) {
-  const cmds = seed.match(new RegExp(`${CMD_MARKER}\r?\n(.*?\`\`\`\n)`, 'gs'));
+  const cmds = seed.match(new RegExp(`${CMD_MARKER}\n(.*?\`\`\`\n)`, 'gs'));
   const commands = cmds?.map(cmd => extractStringFromCode(cmd)?.trim());
   return commands ?? [];
 }
@@ -164,7 +165,7 @@ export function getCommands(seed) {
  */
 export function getFilesWithSeed(seed) {
   const files = seed.match(
-    new RegExp(`#### --"([^"]+)"--\r?\n(.*?\`\`\`\r?\n)`, 'gs')
+    new RegExp(`#### --"([^"]+)"--\n(.*?\`\`\`\n)`, 'gs')
   );
   const filePaths = seed.match(new RegExp(FILE_MARKER_REG, 'gsm'));
   const fileSeeds = files?.map(file => extractStringFromCode(file)?.trim());
@@ -193,7 +194,7 @@ export function isForceFlag(seed) {
  * @returns {string} The stripped codeblock
  */
 export function extractStringFromCode(code) {
-  return code.replace(/.*?```[a-z]+\r?\n(.*?)```.*/s, '$1');
+  return code.replace(/.*?```[a-z]+\n(.*?)```.*/s, '$1');
 }
 
 /**
@@ -229,11 +230,9 @@ export function* seedToIterator(seed) {
   const sections = seed.match(new RegExp(`#### --(((?!#### --).)*\n?)`, 'sg'));
   for (const section of sections) {
     const isFile = section.match(
-      new RegExp(`#### --"([^"]+)"--\r?\n(.*?\`\`\`\r?\n)`, 's')
+      new RegExp(`#### --"([^"]+)"--\n(.*?\`\`\`\n)`, 's')
     );
-    const isCMD = section.match(
-      new RegExp(`#### --cmd--\r?\n(.*?\`\`\`\r?\n)`, 's')
-    );
+    const isCMD = section.match(new RegExp(`#### --cmd--\n(.*?\`\`\`\n)`, 's'));
     if (isFile) {
       const filePath = isFile[1];
       const fileSeed = extractStringFromCode(isFile[2])?.trim();

--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -59,7 +59,7 @@ export async function getLessonFromFile(file, lessonNumber = 1) {
   const fileContent = await readFile(file, 'utf8');
   const mat = fileContent.match(
     new RegExp(
-      `## ${lessonNumber}\n(.*?)\n## (${lessonNumber + 1}|--fcc-end--)`,
+      `## ${lessonNumber}\r?\n(.*?)\n## (${lessonNumber + 1}|--fcc-end--)`,
       's'
     )
   );
@@ -89,8 +89,8 @@ export function getLessonDescription(lesson) {
 export function getLessonHintsAndTests(lesson) {
   const testsString = parseMarker(TEST_MARKER, lesson);
   const hintsAndTestsArr = [];
-  const hints = testsString?.match(/^(.*?)$(?=\n+```js)/gm)?.filter(Boolean);
-  const tests = testsString?.match(/(?<=```js\n).*?(?=```)/gms);
+  const hints = testsString?.match(/^(.*?)$(?=\r?\n+```js)/gm)?.filter(Boolean);
+  const tests = testsString?.match(/(?<=```js\r?\n).*?(?=```)/gms);
 
   if (hints?.length) {
     for (let i = 0; i < hints.length; i++) {
@@ -152,7 +152,7 @@ export function getAfterAll(lesson) {
  * @returns {string[]} The commands of the lesson in order
  */
 export function getCommands(seed) {
-  const cmds = seed.match(new RegExp(`${CMD_MARKER}\n(.*?\`\`\`\n)`, 'gs'));
+  const cmds = seed.match(new RegExp(`${CMD_MARKER}\r?\n(.*?\`\`\`\n)`, 'gs'));
   const commands = cmds?.map(cmd => extractStringFromCode(cmd)?.trim());
   return commands ?? [];
 }
@@ -164,7 +164,7 @@ export function getCommands(seed) {
  */
 export function getFilesWithSeed(seed) {
   const files = seed.match(
-    new RegExp(`#### --"([^"]+)"--\n(.*?\`\`\`\n)`, 'gs')
+    new RegExp(`#### --"([^"]+)"--\r?\n(.*?\`\`\`\r?\n)`, 'gs')
   );
   const filePaths = seed.match(new RegExp(FILE_MARKER_REG, 'gsm'));
   const fileSeeds = files?.map(file => extractStringFromCode(file)?.trim());
@@ -193,7 +193,7 @@ export function isForceFlag(seed) {
  * @returns {string} The stripped codeblock
  */
 export function extractStringFromCode(code) {
-  return code.replace(/.*?```[a-z]+\n(.*?)```.*/s, '$1');
+  return code.replace(/.*?```[a-z]+\r?\n(.*?)```.*/s, '$1');
 }
 
 /**
@@ -229,9 +229,11 @@ export function* seedToIterator(seed) {
   const sections = seed.match(new RegExp(`#### --(((?!#### --).)*\n?)`, 'sg'));
   for (const section of sections) {
     const isFile = section.match(
-      new RegExp(`#### --"([^"]+)"--\n(.*?\`\`\`\n)`, 's')
+      new RegExp(`#### --"([^"]+)"--\r?\n(.*?\`\`\`\r?\n)`, 's')
     );
-    const isCMD = section.match(new RegExp(`#### --cmd--\n(.*?\`\`\`\n)`, 's'));
+    const isCMD = section.match(
+      new RegExp(`#### --cmd--\r?\n(.*?\`\`\`\r?\n)`, 's')
+    );
     if (isFile) {
       const filePath = isFile[1];
       const fileSeed = extractStringFromCode(isFile[2])?.trim();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@freecodecamp/freecodecamp-os",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
   "author": "freeCodeCamp",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Package used for freeCodeCamp projects with the freeCodeCamp Courses VSCode extension",
   "scripts": {
     "start": "npm run build:client && node ./.freeCodeCamp/tooling/server.js",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Inspiration: https://github.com/freeCodeCamp/web3-curriculum/pull/91

This should fix cases where someone's fs has decided to re-save all their files, and added CRLF instead of the more common LF.

Closes https://github.com/freeCodeCamp/web3-curriculum/issues/87
Closes https://github.com/freeCodeCamp/web3-curriculum/issues/70
Closes https://github.com/freeCodeCamp/web3-curriculum/issues/69
Closes https://github.com/freeCodeCamp/near-curriculum/issues/23