### PR TITLE
fix(1.8.3): adjust import pathing

### DIFF
--- a/.freeCodeCamp/tooling/test-utils.js
+++ b/.freeCodeCamp/tooling/test-utils.js
@@ -223,7 +223,7 @@ async function getTerminalOutput() {
  * @returns {Promise<ReturnType<typeof import>>}
  */
 async function importSansCache(path) {
-  const cacheBustingModulePath = `${path}?update=${Date.now()}`;
+  const cacheBustingModulePath = `${join(ROOT, path)}?update=${Date.now()}`;
   return await import(cacheBustingModulePath);
 }
 

--- a/.freeCodeCamp/tooling/test.js
+++ b/.freeCodeCamp/tooling/test.js
@@ -100,7 +100,7 @@ export default async function runTests(ws, projectDashedName) {
         });
       } catch (e) {
         if (!(e instanceof AssertionError)) {
-          logover.error(e);
+          logover.error(`Test #${i + 1}:`, e);
         }
 
         const testState = {
@@ -134,7 +134,6 @@ export default async function runTests(ws, projectDashedName) {
           await runLesson(ws, projectDashedName);
           updateHints(ws, '');
         }
-
       } else {
         updateHints(
           ws,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@freecodecamp/freecodecamp-os",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "7.21.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
   "author": "freeCodeCamp",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Package used for freeCodeCamp projects with the freeCodeCamp Courses VSCode extension",
   "scripts": {
     "start": "npm run build:client && node ./.freeCodeCamp/tooling/server.js",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This fixes an issue like:

```bash
🔴 ERROR:  2023-03-28 11:50:59 Test #21: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/shauh/solana-curriculum/node_modules/@freecodecamp/freecodecamp-os/.freeCodeCamp/tooling/build-a-university-certification-nft/_answer/index.js' imported from /home/shauh/solana-curriculum/node_modules/@freecodecamp/freecodecamp-os/.freeCodeCamp/tooling/test-utils.js
```