### PR TITLE
fix(docs): update mdbook-admonish to 1.9.0

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -35,7 +35,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
-          cargo install mdbook-admonish
+          cargo install --git https://github.com/tommilligan/mdbook-admonish --tag v1.9.0
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,7 +9,7 @@ title = "freeCodeCampOS"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "2.0.0"    # do not edit: managed by `mdbook-admonish install`
+assets_version = "2.0.1" # do not edit: managed by `mdbook-admonish install`
 
 [output]
 

--- a/docs/mdbook-admonish.css
+++ b/docs/mdbook-admonish.css
@@ -77,6 +77,7 @@ a.admonition-anchor-link::before {
 
 :is(.admonition-title, summary) {
   position: relative;
+  min-height: 4rem;
   margin-block: 0;
   margin-inline: -1.6rem -1.2rem;
   padding-block: 0.8rem;

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -34,14 +34,13 @@ The most up-to-date definitions can be found here: https://github.com/freeCodeCa
 
 This is a string command run in the terminal before the course is opened.
 
-<!-- prettier-ignore -->
-~~~admonish example
+````admonish example
 ```json
 {
   "prepare": "npm i"
 }
 ```
-~~~
+````
 
 #### `workspace`
 
@@ -57,8 +56,7 @@ This configures files, terminals, and previews to open when the course is opened
 - `previews.showLoader`: whether or not to show the loader. This is useful if setup takes a long time - `boolean`
 - `previews.timeout`: how long to show the loader before trying the `url` - `number` (ms)
 
-<!-- prettier-ignore -->
-~~~admonish example
+````admonish example
 ```json
 {
   "workspace": {
@@ -84,7 +82,7 @@ This configures files, terminals, and previews to open when the course is opened
   }
 }
 ```
-~~~
+````
 
 #### `bash`
 
@@ -154,8 +152,7 @@ WIP
 
 ### Optional Configuration
 
-<!-- prettier-ignore -->
-~~~admonish example
+````admonish example
 ```json
 [
   {
@@ -172,4 +169,4 @@ WIP
   }
 ]
 ```
-~~~
+````

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -45,8 +45,7 @@ Add the following required configuration:
 }
 ```
 
-<!-- prettier-ignore -->
-~~~admonish attention
+````admonish attention
 Technically, the `develop-course` and `run-course` scripts have to be specific values (see below), but you can customize the command with other conditions.
 
 ```json
@@ -57,10 +56,9 @@ Technically, the `develop-course` and `run-course` scripts have to be specific v
   }
 }
 ```
-~~~
+````
 
-<!-- prettier-ignore -->
-~~~admonish example collapsible=true
+````admonish example collapsible=true
 ```json
 {
   "path": ".",
@@ -80,7 +78,7 @@ Technically, the `develop-course` and `run-course` scripts have to be specific v
   }
 }
 ```
-~~~
+````
 
 ```admonish info
 There are many more configuration options available. See the [configuration](./configuration.md) page for more details.
@@ -121,13 +119,12 @@ mkdir <LOCALE_DIR>
 touch <LOCALE_DIR>/<PROJECT_DASHED_NAME>.md
 ```
 
-<!-- prettier-ignore -->
-~~~admonish example
+````admonish example
 ```bash
 mkdir curriculum/locales/english
 touch curriculum/locales/english/learn-x-by-building-y.md
 ```
-~~~
+````
 
 Create the project boilerplate/working directory in the root:
 
@@ -139,8 +136,7 @@ mkdir <PROJECT_DASHED_NAME>
 WIP
 ```
 
-<!-- prettier-ignore -->
-~~~admonish attention title="Required Files"
+````admonish attention title="Required Files"
 ```txt
 <COURSE_DIR>/
 ├── freecodecamp.conf.json
@@ -164,4 +160,4 @@ If using the `tooling` feature:
 ```
 
 WIP
-~~~
+````

--- a/docs/src/project-syntax.md
+++ b/docs/src/project-syntax.md
@@ -20,12 +20,11 @@ The project title requires the `TITLE` and `SUB_TITLE` to be separated by a dash
 ## <LESSON_NUMBER>
 ```
 
-<!-- prettier-ignore -->
-~~~admonish example collapsible=true
+````admonish example collapsible=true
 ```markdown
 ## 1
 ```
-~~~
+````
 
 ### Description (Instruction)
 
@@ -35,29 +34,27 @@ The project title requires the `TITLE` and `SUB_TITLE` to be separated by a dash
 <DESCRIPTION_CONTENT>
 ```
 
-<!-- prettier-ignore -->
-~~~admonish example collapsible=true
+````admonish example collapsible=true
 ```markdown
 ### --description--
 
 This is the description content.
 ```
-~~~
+````
 
 ### Tests
 
-```markdown
+````markdown
 ### --tests--
 
 <TEST_TEXT>
 
-\`\`\`js
+```js
 <TEST_CODE>
-\`\`\`
 ```
+````
 
-<!-- prettier-ignore -->
-~~~admonish example collapsible=true
+`````admonish example collapsible=true
 ````markdown
 ### --tests--
 
@@ -68,28 +65,27 @@ await new Promise(resolve => setTimeout(resolve, 2000));
 assert.equal(true, true);
 ```
 ````
-~~~
+`````
 
 ### Seed
 
-```markdown
+````markdown
 #### --seed--
 
 #### --"<FILE_PATH>"--
 
-\`\`\`<FILE_EXTENSION>
+```<FILE_EXTENSION>
 <FILE_CONTENT>
-\`\`\`
+```
 
 #### --cmd--
 
-\`\`\`bash
+```bash
 <COMMAND>
-\`\`\`
 ```
+````
 
-<!-- prettier-ignore -->
-~~~admonish example collapsible=true
+`````admonish example collapsible=true
 ````markdown
 #### --seed--
 
@@ -105,7 +101,7 @@ assert.equal(true, true);
 npm install
 ```
 ````
-~~~
+`````
 
 ### End Discriminator
 


### PR DESCRIPTION
Updates mdbook admonish to `1.9.0` which allows quadruple backticks for admonish blocks.
