### PR TITLE
refactor: seed lessons with `runLessonSeed`

### DIFF
--- a/.freeCodeCamp/tooling/env.js
+++ b/.freeCodeCamp/tooling/env.js
@@ -14,7 +14,14 @@ export const freeCodeCampConfig = await getConfig();
 export async function getState() {
   let defaultState = {
     currentProject: null,
-    locale: 'english'
+    locale: 'english',
+    lastSeed: {
+      projectDashedName: null,
+      // All lessons start at 1, but the logic for whether to seed a lesson
+      // or not is based on the current lesson matching the last seeded lesson
+      // So, to ensure the first lesson is seeded, this is 0
+      lessonNumber: 0
+    }
   };
   try {
     const state = JSON.parse(

--- a/.freeCodeCamp/tooling/git/build.js
+++ b/.freeCodeCamp/tooling/git/build.js
@@ -65,6 +65,7 @@ async function buildProject() {
       const filesWithSeed = getFilesWithSeed(seed);
       try {
         await runCommands(commands);
+        // TODO: Not correct signature
         await runSeed(filesWithSeed);
       } catch (e) {
         logover.error('🔴 Failed to run seed for lesson: ', lessonNumber);

--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -229,6 +229,8 @@ function parseMarker(marker, lesson) {
 export function* seedToIterator(seed) {
   const sections = seed.match(new RegExp(`#### --(((?!#### --).)*\n?)`, 'sg'));
   for (const section of sections) {
+    if (isForceFlag(section)) { continue; }
+
     const isFile = section.match(
       new RegExp(`#### --"([^"]+)"--\n(.*?\`\`\`\n)`, 's')
     );

--- a/.freeCodeCamp/tooling/reset.js
+++ b/.freeCodeCamp/tooling/reset.js
@@ -7,6 +7,10 @@ import { logover } from './logger.js';
 import { getLessonFromFile, getLessonSeed } from './parser.js';
 import { runCommand, runLessonSeed } from './seed.js';
 
+/**
+ * Resets the current project by running, in order, every seed
+ * @param {WebSocket} ws
+ */
 export async function resetProject(ws) {
   // Get commands and handle file setting
   const { currentProject } = await getState();

--- a/.freeCodeCamp/tooling/seed.js
+++ b/.freeCodeCamp/tooling/seed.js
@@ -67,23 +67,6 @@ export async function runCommand(command, path = '.') {
 
 /**
  * Runs the given array of files with seed
- * @param {[string, string][]} filesWithSeed - [[filePath, fileSeed]]
- *
- * @deprecated Prefer to use `runLessonSeed` instead
- */
-export async function runSeedDeprecated(filesWithSeed) {
-  try {
-    for (const [filePath, fileSeed] of filesWithSeed) {
-      const filePathWithRoot = `${filePath}`;
-      await writeFile(filePathWithRoot, fileSeed);
-    }
-  } catch (e) {
-    return Promise.reject(e);
-  }
-  return Promise.resolve();
-}
-/**
- * Runs the given array of files with seed
  */
 export async function runSeed(fileSeed, filePath, projectPath) {
   const path = join(ROOT, projectPath, filePath);

--- a/.freeCodeCamp/tooling/seed.js
+++ b/.freeCodeCamp/tooling/seed.js
@@ -96,18 +96,18 @@ export async function runSeed(fileSeed, filePath, projectPath) {
   await writeFile(path, fileSeed);
 }
 
-export async function runLessonSeed(seed, currentProject, lessonNumber) {
+export async function runLessonSeed(seed, projectPath, lessonNumber) {
   const seedGenerator = seedToIterator(seed);
   try {
     for (const cmdOrFile of seedGenerator) {
       if (typeof cmdOrFile === 'string') {
-        const { stdout, stderr } = await runCommand(cmdOrFile, currentProject);
+        const { stdout, stderr } = await runCommand(cmdOrFile, projectPath);
         if (stdout || stderr) {
           logover.debug(stdout, stderr);
         }
       } else {
         const { filePath, fileSeed } = cmdOrFile;
-        await runSeed(fileSeed, filePath, currentProject);
+        await runSeed(fileSeed, filePath, projectPath);
       }
     }
   } catch (e) {

--- a/.freeCodeCamp/tooling/seed.js
+++ b/.freeCodeCamp/tooling/seed.js
@@ -3,8 +3,6 @@ import { join } from 'path';
 import {
   getLessonFromFile,
   getLessonSeed,
-  getCommands,
-  getFilesWithSeed,
   seedToIterator
 } from './parser.js';
 import { ROOT, getState, freeCodeCampConfig } from './env.js';
@@ -17,23 +15,19 @@ const execute = promisify(exec);
 
 export async function seedLesson(ws, project) {
   // TODO: Use ws to display loader whilst seeding
-  const lessonNumber = project.currentLesson;
+  const { currentLesson: lessonNumber, dashedName: projectPath } = project;
   const { locale } = await getState();
   const projectFile = join(
     ROOT,
     freeCodeCampConfig.curriculum.locales[locale],
-    project.dashedName + '.md'
+    projectPath + '.md'
   );
 
   try {
     const lesson = await getLessonFromFile(projectFile, lessonNumber);
     const seed = getLessonSeed(lesson);
 
-    const commands = getCommands(seed);
-    const filesWithSeed = getFilesWithSeed(seed);
-
-    await runCommands(commands);
-    await runSeedDeprecated(filesWithSeed);
+    await runLessonSeed(seed, projectPath, lessonNumber);
   } catch (e) {
     updateError(ws, e);
     logover.error(e);

--- a/.freeCodeCamp/tooling/seed.js
+++ b/.freeCodeCamp/tooling/seed.js
@@ -68,27 +68,27 @@ export async function runCommand(command, path = '.') {
 /**
  * Runs the given array of files with seed
  */
-export async function runSeed(fileSeed, filePath, projectPath) {
-  const path = join(ROOT, projectPath, filePath);
+export async function runSeed(fileSeed, filePath, dashedName) {
+  const path = join(ROOT, dashedName, filePath);
   await writeFile(path, fileSeed);
 }
 
-export async function runLessonSeed(seed, projectPath, lessonNumber) {
+export async function runLessonSeed(seed, dashedName, currentLesson) {
   const seedGenerator = seedToIterator(seed);
   try {
     for (const cmdOrFile of seedGenerator) {
       if (typeof cmdOrFile === 'string') {
-        const { stdout, stderr } = await runCommand(cmdOrFile, projectPath);
+        const { stdout, stderr } = await runCommand(cmdOrFile, dashedName);
         if (stdout || stderr) {
           logover.debug(stdout, stderr);
         }
       } else {
         const { filePath, fileSeed } = cmdOrFile;
-        await runSeed(fileSeed, filePath, projectPath);
+        await runSeed(fileSeed, filePath, dashedName);
       }
     }
   } catch (e) {
-    logover.error('Failed to run seed for lesson: ', lessonNumber);
+    logover.error('Failed to run seed for lesson: ', currentLesson);
     throw new Error(e);
   }
 }

--- a/.freeCodeCamp/tooling/seed.js
+++ b/.freeCodeCamp/tooling/seed.js
@@ -15,19 +15,19 @@ const execute = promisify(exec);
 
 export async function seedLesson(ws, project) {
   // TODO: Use ws to display loader whilst seeding
-  const { currentLesson: lessonNumber, dashedName: projectPath } = project;
+  const { currentLesson, dashedName } = project;
   const { locale } = await getState();
   const projectFile = join(
     ROOT,
     freeCodeCampConfig.curriculum.locales[locale],
-    projectPath + '.md'
+    dashedName + '.md'
   );
 
   try {
-    const lesson = await getLessonFromFile(projectFile, lessonNumber);
+    const lesson = await getLessonFromFile(projectFile, currentLesson);
     const seed = getLessonSeed(lesson);
 
-    await runLessonSeed(seed, projectPath, lessonNumber);
+    await runLessonSeed(seed, dashedName, currentLesson);
   } catch (e) {
     updateError(ws, e);
     logover.error(e);

--- a/config/projects.json
+++ b/config/projects.json
@@ -8,7 +8,9 @@
     "isPublic": true,
     "currentLesson": 1,
     "runTestsOnWatch": true,
-    "isResetEnabled": true
+    "seedEveryLesson": true,
+    "isResetEnabled": true,
+    "numberOfLessons": 6
   },
   {
     "id": 1,
@@ -17,6 +19,7 @@
     "isIntegrated": true,
     "description": "In this course, you will build x using y.",
     "isPublic": true,
-    "currentLesson": 1
+    "currentLesson": 1,
+    "numberOfLessons": 1
   }
 ]

--- a/curriculum/locales/english/learn-x-by-building-y.md
+++ b/curriculum/locales/english/learn-x-by-building-y.md
@@ -15,30 +15,18 @@ const a = 1;
 You should declare a variable named `a`.
 
 ```js
-const test = `console.assert(typeof a);`;
-const filePath = 'learn-x-by-building-y/index.js';
-const cb = (stdout, stderr) => {
-  assert.isEmpty(stderr);
-  assert.exists(stdout);
-};
-await __helpers.javascriptTest(filePath, test, cb);
+assert.fail();
 ```
 
 You should give `a` a value of `1`.
 
 ```js
-const test = `console.assert(a === 1, \`expected \${a} to equal 1\`);`;
-const filePath = 'learn-x-by-building-y/index.js';
-const cb = (stdout, stderr) => {
-  assert.isEmpty(stderr);
-  assert.exists(stdout);
-};
-await __helpers.javascriptTest(filePath, test, cb);
+assert.fail();
 ```
 
 ### --seed--
 
-#### --"index.js"--
+#### --"learn-x-by-building-y/index.js"--
 
 ```js
 // I am an example boilerplate file
@@ -67,7 +55,7 @@ assert.equal(true, true);
 
 ### --seed--
 
-#### --"index.js"--
+#### --"learn-x-by-building-y/index.js"--
 
 ```javascript
 // I am an example boilerplate file
@@ -100,16 +88,16 @@ echo "I should run first"
 #### --cmd--
 
 ```bash
-mkdir test
+mkdir learn-x-by-building-y/test
 ```
 
 #### --cmd--
 
 ```bash
-touch test/index.ts
+touch learn-x-by-building-y/test/index.ts
 ```
 
-#### --"test/index.ts"--
+#### --"learn-x-by-building-y/test/index.ts"--
 
 ```ts
 const test: string = 'test';

--- a/tooling/helpers.js
+++ b/tooling/helpers.js
@@ -24,6 +24,7 @@ export async function javascriptTest(filePath, test, cb) {
     const ensureFileContents = fileContents.replace(testString, '');
     writeFileSync(PATH_TO_FILE, ensureFileContents, 'utf-8');
     await cb(std.stdout, std.stderr);
+    await new Promise(resolve => setTimeout(resolve, 1500));
   }
 }
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Ref: #264 

---
- Changes to use `runLessonSeed` for initial lesson seeding too.
- Removes `runSeedDeprecated`.
- Related to `runSeedDeprecated`: `getCommands`, `getFilesWithSeed`, `runCommands` are now referenced only in the `tooling/git/build.js` is that used for anything? And/or should I add `runLessonSeed` to it as well, plus remove functions unused after that?