### PR TITLE
fix(.github): make unlink optional

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -14,6 +14,7 @@ assets_version = "2.0.1"    # do not edit: managed by `mdbook-admonish install`
 [output]
 
 [output.unlink]
+optional = true
 ignore-files = ["CHANGELOG.md"]
 
 [output.html]


### PR DESCRIPTION
When deploying, we do not run `mdbook-unlink`, so it should be optional. We might need to find a way to confirm it is not optional for the link checking.