### PR TITLE
fix(.github): adjust book path

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187 # v1
         with:
-          path: ./docs/book
+          path: ./docs/book/html
 
   # Deployment job
   deploy:

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -22,3 +22,7 @@ default-theme = "dark"
 preferred-dark-theme = "dark"
 additional-css = ["./mdbook-admonish.css"]
 mathjax-support = true
+site-url = "/freeCodeCampOS/"
+
+[build]
+build-dir = "book" # the directory where the output is placed


### PR DESCRIPTION
> If more than one output table is included, this changes the behavior for the layout of the output directory. If there is only one backend, then it places its output directly in the book directory (see [build.build-dir](https://rust-lang.github.io/mdBook/format/configuration/general.html#build-options) to override this location). If there is more than one backend, then each backend is placed in a separate directory underneath book. For example, the above would have directories `book/html` and `book/wordcount`.
> https://rust-lang.github.io/mdBook/format/configuration/renderers.html

Closes #277 

I added `output.html.site-url` and `build.build-dir` to be explicit - not necessarily a part of the fix.