### PR TITLE
fix(2.0.0): match controlWrapper to docs def

### DIFF
--- a/.freeCodeCamp/tooling/test-utils.js
+++ b/.freeCodeCamp/tooling/test-utils.js
@@ -31,12 +31,9 @@ async function controlWrapper(cb, { timeout = 10000, stepSize = 250 }) {
     const interval = setInterval(async () => {
       try {
         const response = await cb();
-        if (response) {
-          clearInterval(interval);
-          resolve(response);
-        }
+        resolve(response);
       } catch (e) {
-        logover.error(e);
+        logover.debug(e);
       }
     }, stepSize);
     setTimeout(() => {
@@ -63,15 +60,11 @@ const execute = promisify(exec);
  * @returns {Promise<{stdout, stderr}>}
  */
 async function getCommandOutput(command, path = '') {
-  try {
-    const cmdOut = await execute(command, {
-      cwd: join(ROOT, path),
-      shell: '/bin/bash'
-    });
-    return cmdOut;
-  } catch (err) {
-    return err;
-  }
+  const cmdOut = await execute(command, {
+    cwd: join(ROOT, path),
+    shell: '/bin/bash'
+  });
+  return cmdOut;
 }
 
 /**
@@ -85,7 +78,7 @@ async function getCWD() {
 
 /**
  * Get the `.logs/.bash_history.log` file contents, or `throw` is not found
- * @param {number?} howManyBack The `nth` log from the history
+ * @param {number} howManyBack The `nth` log from the history
  * @returns {Promise<string>}
  */
 async function getLastCommand(howManyBack = 0) {

--- a/.freeCodeCamp/tooling/test.js
+++ b/.freeCodeCamp/tooling/test.js
@@ -1,6 +1,5 @@
 // These are used in the local scope of the `eval` in `runTests`
-import fs from 'fs';
-import { assert, AssertionError } from 'chai';
+import { assert, AssertionError, expect, config as chaiConfig } from 'chai';
 import __helpers_c from './test-utils.js';
 
 import {

--- a/docs/src/CHANGELOG.md
+++ b/docs/src/CHANGELOG.md
@@ -15,6 +15,7 @@
 - remove `__helpers.copyDirectory`
 - remove `__helpers.copyProjectFiles`
 - remove `__helpers.fileExists`
+- update `controlWrapper` to match documented API
 
 ### Update
 
@@ -25,7 +26,7 @@
 
 ### Migration Guide
 
-1. Refactor tests to use global `fs` instead of removed `__helpers` functions.
+1. Refactor tests to use Nodejs API instead of removed `__helpers` functions.
 
 ## [1.8.5] - UNRELEASED
 

--- a/docs/src/testing/globals.md
+++ b/docs/src/testing/globals.md
@@ -2,17 +2,23 @@
 
 None of the globals are within the `__helpers` module.
 
-### `chai.assert`
+### `chai`
 
-The `chai.assert` module: <https://www.chaijs.com/api/assert/>
+#### `assert`
 
-### `fs`
+The `assert` module: <https://www.chaijs.com/api/assert/>
 
-The `fs` module for file system operations: <https://nodejs.org/api/fs.html>
+#### `expect`
 
-### `join`
+The `expect` module: <https://www.chaijs.com/api/bdd/>
 
-The `join` function from the `path` module: <https://nodejs.org/dist/docs/api/path.html#pathjoinpaths>
+#### `config as chaiConfig`
+
+The `config` module: <https://www.chaijs.com/guide/styles/#configuration>
+
+#### `AssertionError`
+
+This is the `AssertionError` class from the `assert` module.
 
 ### `logover`
 
@@ -23,10 +29,6 @@ This is mostly useful for debugging, as any logs will be output in the freeCodeC
 ### `ROOT`
 
 The root of the workspace.
-
-### `import`
-
-As expected, the `import` function allows any other available module to be dynamically imported.
 
 ## Collisions
 

--- a/docs/src/testing/test-utilities.md
+++ b/docs/src/testing/test-utilities.md
@@ -51,6 +51,10 @@ const bashHistory = await __helpers.getBashHistory();
 
 Returns the output of a command called from the given path relative to the root of the workspace.
 
+```admonish danger title="Safety"
+Throws if path is not a valid POSIX/DOS path, and if promisified `exec` throws.
+```
+
 ```typescript
 function getCommandOutput(
   command: string,


### PR DESCRIPTION
- Remove `fs` as a global in `test.js`
- Add `expect` and `chai as chaiConfig` to global in `test.js`
- Change `controlWrapper` to match behaviour outlined in docs
- Change `getCommandOutput` to throw on `exec`