### PR TITLE
feat(1.9.0): add blocking tests flag

### DIFF
--- a/.freeCodeCamp/tooling/env.js
+++ b/.freeCodeCamp/tooling/env.js
@@ -62,6 +62,8 @@ export async function getProjectConfig(project) {
     runTestsOnWatch: false,
     lastKnownLessonWithHash: 1,
     seedEveryLesson: false,
+    blockingTests: false,
+    breakOnFailure: false,
     useGitBuildOnProduction: false // TODO: Necessary?
   };
   if (!proj) {

--- a/docs/src/CHANGELOG.md
+++ b/docs/src/CHANGELOG.md
@@ -15,6 +15,17 @@
 - dependency @types/react to v18.0.38
 - dependency @types/node to v18.15.13
 
+## [1.9.0] - 2023-05-20
+
+### Add
+
+- add `blockingTests` flag
+- add `breakOnFailure` flag
+
+### Bugs
+
+- when `blockingTests && breakOnFailure`, proceeding tests appear to hang in client
+
 ## [1.8.4] - 2023-04-19
 
 ### Fix

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -226,8 +226,10 @@ This configures files, terminals, and previews to open when the course is opened
     "isPublic": true,
     "currentLesson": 1,
     "runTestsOnWatch": true,
+    "blockingTests": false,
+    "breakOnFailure": false,
     "isResetEnabled": true,
-    "numLessons": 10
+    "numberOfLessons": 10
   }
 ]
 ```

--- a/docs/src/testing/lifecycle.md
+++ b/docs/src/testing/lifecycle.md
@@ -8,7 +8,9 @@ The lifecycle of the testing system follows:
 - If any `--before-all--` ops fail, an error is printed to the console
 - If any `--before-all--` ops fail, the tests **continue** to run
 
-3. Server evaluates all tests asynchronously
+3. Server evaluates all tests asynchronously[^1]
 4. Server evaluates any `--after-all--` ops
 
 - If any `--after-all--` ops fail, an error is printed to the console
+
+[^1]: Tests can be configured to run in order, in a blocking fashion with the `blockingTests` configuration option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
-  "version": "1.8.4",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@freecodecamp/freecodecamp-os",
-      "version": "1.8.4",
+      "version": "1.9.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "7.21.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
   "author": "freeCodeCamp",
-  "version": "1.8.4",
+  "version": "1.9.0",
   "description": "Package used for freeCodeCamp projects with the freeCodeCamp Courses VSCode extension",
   "scripts": {
     "start": "npm run build:client && node ./.freeCodeCamp/tooling/server.js",


### PR DESCRIPTION
This is useful for tests that make IO/FS ops that should not interfere with one another.

As mentioned in the CHANGELOG, there is a known bug whereby with the `breakOnFailure` flag is enabled, the client appears to show proceeding tests as hanging.

This should be fixed with #232 , as both will require a way to stop the test promise, but still communicate the result to the client.