### PR TITLE
fix(.github): rely on npm to prevent duplicate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - run: |
-          VERSION=$(npm pkg get version)
-          # Exit if the version is not changed from the previous commit
-          if [ "$(git diff HEAD^ HEAD -- package.json | grep version)" = "" ]; then
-            echo "No version change, skipping publish"
-            exit 1
-          fi
-          echo "Publishing version $VERSION"
+
       - name: Publish to NPM
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:


### PR DESCRIPTION
Fixes releases from not happening on push to prod, because two consecutive commits do not change the `package.json` > version`.