### PR TITLE
feat(2.1.0): add cancellable tests

### DIFF
--- a/.freeCodeCamp/client/components/controls.tsx
+++ b/.freeCodeCamp/client/components/controls.tsx
@@ -1,20 +1,43 @@
-import { F, ProjectI } from '../types';
+import { useEffect, useState } from 'react';
+import { F, ProjectI, TestType } from '../types';
 
 interface ControlsProps {
+  cancelTests: F<void, void>;
   runTests: F<void, void>;
   resetProject?: F<void, void>;
   isResetEnabled?: ProjectI['isResetEnabled'];
+  tests: TestType[];
 }
 
 export const Controls = ({
+  cancelTests,
   runTests,
   resetProject,
-  isResetEnabled
+  isResetEnabled,
+  tests
 }: ControlsProps) => {
+  const [isTestsRunning, setIsTestsRunning] = useState(false);
+
+  useEffect(() => {
+    if (tests.some(t => t.isLoading)) {
+      setIsTestsRunning(true);
+    } else {
+      setIsTestsRunning(false);
+    }
+  }, [tests]);
+
+  function handleTests() {
+    if (isTestsRunning) {
+      cancelTests();
+    } else {
+      runTests();
+    }
+  }
+
   return (
     <section className='project-controls'>
-      <button className='secondary-cta' onClick={() => runTests()}>
-        Run Tests
+      <button className='secondary-cta' onClick={handleTests}>
+        {isTestsRunning ? 'Cancel Tests' : 'Run Tests'}
       </button>
       {resetProject && (
         <button

--- a/.freeCodeCamp/client/index.tsx
+++ b/.freeCodeCamp/client/index.tsx
@@ -179,6 +179,10 @@ const App = () => {
     sock(Events.GO_TO_PREVIOUS_LESSON);
   }
 
+  function cancelTests() {
+    sock(Events.CANCEL_TESTS);
+  }
+
   if (alertCamper) {
     return (
       <>
@@ -195,17 +199,18 @@ const App = () => {
         {project ? (
           <Project
             {...{
-              project,
-              lessonNumber,
-              description,
-              tests,
-              hints,
+              cancelTests,
               cons,
-              isLoading,
-              runTests,
-              resetProject,
+              description,
               goToNextLesson,
-              goToPreviousLesson
+              goToPreviousLesson,
+              hints,
+              isLoading,
+              lessonNumber,
+              project,
+              resetProject,
+              runTests,
+              tests
             }}
           />
         ) : (

--- a/.freeCodeCamp/client/templates/project.tsx
+++ b/.freeCodeCamp/client/templates/project.tsx
@@ -6,20 +6,22 @@ import { Output } from '../components/output';
 import './project.css';
 
 export interface ProjectProps {
-  runTests: F<void, void>;
-  resetProject: F<void, void>;
+  cancelTests: F<void, void>;
   goToNextLesson: F<void, void>;
   goToPreviousLesson: F<void, void>;
+  resetProject: F<void, void>;
+  runTests: F<void, void>;
+  cons: ConsoleError[];
+  description: string;
+  hints: string;
   isLoading: boolean;
   lessonNumber: number;
-  description: string;
-  tests: TestType[];
-  hints: string;
-  cons: ConsoleError[];
   project: ProjectI;
+  tests: TestType[];
 }
 
 export const Project = ({
+  cancelTests,
   runTests,
   resetProject,
   goToNextLesson,
@@ -51,11 +53,17 @@ export const Project = ({
 
         <Controls
           {...(project.isIntegrated
-            ? { runTests }
+            ? {
+                cancelTests,
+                runTests,
+                tests
+              }
             : {
+                cancelTests,
                 runTests,
                 resetProject,
-                isResetEnabled: project.isResetEnabled
+                isResetEnabled: project.isResetEnabled,
+                tests
               })}
         />
 

--- a/.freeCodeCamp/client/types/index.ts
+++ b/.freeCodeCamp/client/types/index.ts
@@ -15,8 +15,8 @@ export enum Events {
   REQUEST_DATA = 'request-data',
   GO_TO_NEXT_LESSON = 'go-to-next-lesson',
   GO_TO_PREVIOUS_LESSON = 'go-to-previous-lesson',
-  SELECT_PROJECT = 'select-project'
-  // CANCEL_TESTS = 'cancel-tests'
+  SELECT_PROJECT = 'select-project',
+  CANCEL_TESTS = 'cancel-tests'
 }
 
 export type TestType = {

--- a/.freeCodeCamp/tooling/hot-reload.js
+++ b/.freeCodeCamp/tooling/hot-reload.js
@@ -2,7 +2,7 @@
 // and executing the command to run the tests for the next (current) lesson
 import { getState, getProjectConfig, ROOT, freeCodeCampConfig } from './env.js';
 import { runLesson } from './lesson.js';
-import { runTests } from './test.js';
+import { runTests } from './tests/main.js';
 import { watch } from 'chokidar';
 import { logover } from './logger.js';
 

--- a/.freeCodeCamp/tooling/lesson.js
+++ b/.freeCodeCamp/tooling/lesson.js
@@ -40,7 +40,6 @@ export async function runLesson(ws, projectDashedName) {
     const description = getLessonDescription(lesson);
 
     updateProject(ws, project);
-    resetBottomPanel(ws);
 
     if (!isIntegrated) {
       const textsAndTestsArr = getLessonTextsAndTests(lesson);
@@ -54,6 +53,7 @@ export async function runLesson(ws, projectDashedName) {
         }, [])
       );
     }
+    resetBottomPanel(ws);
 
     const { projectTopic, currentProject } = await getProjectTitle(projectFile);
     updateProjectHeading(ws, {

--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -203,7 +203,7 @@ export function getAfterEach(lesson) {
   const beforeEach = parseMarker(AFTER_EACH_MARKER, lesson);
   if (!beforeEach) return null;
   const beforeEachCommand = extractStringFromCode(beforeEach);
-  return beforeEachCommand ?? null;
+  return beforeEachCommand;
 }
 
 /**

--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -13,6 +13,7 @@ const HINTS_MARKER = `### --hints--`;
 const BEFORE_ALL_MARKER = '### --before-all--';
 const AFTER_ALL_MARKER = '### --after-all--';
 const BEFORE_EACH_MARKER = '### --before-each--';
+const AFTER_EACH_MARKER = '### --after-each--';
 const NEXT_MARKER_REG = `\n###? --`;
 const CMD_MARKER = '#### --cmd--';
 const FILE_MARKER_REG = '(?<=#### --")[^"]+(?="--)';
@@ -191,6 +192,18 @@ export function getAfterAll(lesson) {
   if (!afterAll) return null;
   const afterAllCommand = extractStringFromCode(afterAll);
   return afterAllCommand ?? null;
+}
+
+/**
+ * Gets the command/script to run after running each lesson test
+ * @param {string} lesson - The lesson content
+ * @returns {string | null} The command to run after running each lesson test
+ */
+export function getAfterEach(lesson) {
+  const beforeEach = parseMarker(AFTER_EACH_MARKER, lesson);
+  if (!beforeEach) return null;
+  const beforeEachCommand = extractStringFromCode(beforeEach);
+  return beforeEachCommand ?? null;
 }
 
 /**

--- a/.freeCodeCamp/tooling/server.js
+++ b/.freeCodeCamp/tooling/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { readFile } from 'fs/promises';
-import { runTests } from './test.js';
+import { runTests } from './tests/main.js';
 import {
   getProjectConfig,
   getState,

--- a/.freeCodeCamp/tooling/tests/main.js
+++ b/.freeCodeCamp/tooling/tests/main.js
@@ -1,0 +1,194 @@
+import { AssertionError } from 'chai';
+
+/**
+ * Run the given project's tests
+ * @param {WebSocket} ws
+ * @param {string} projectDashedName
+ */
+export async function runTests(ws, projectDashedName) {
+  const project = await getProjectConfig(projectDashedName);
+  const { locale } = await getState();
+  // toggleLoaderAnimation(ws);
+  const lessonNumber = project.currentLesson;
+  const projectFile = join(
+    ROOT,
+    freeCodeCampConfig.curriculum.locales[locale],
+    project.dashedName + '.md'
+  );
+  let testsState = [];
+  try {
+    const lesson = await getLessonFromFile(projectFile, lessonNumber);
+    const beforeAll = getBeforeAll(lesson);
+    const beforeEach = getBeforeEach(lesson);
+    const afterAll = getAfterAll(lesson);
+
+    if (beforeAll) {
+      try {
+        logover.debug('Starting: --before-all-- hook');
+        await eval(`(async () => {${beforeAll}})()`);
+        logover.debug('Finished: --before-all-- hook');
+      } catch (e) {
+        logover.error('--before-all-- hook failed to run:');
+        logover.error(e);
+      }
+    }
+    // toggleLoaderAnimation(ws);
+
+    const hints = getLessonHints(lesson);
+
+    const textsAndTestsArr = getLessonTextsAndTests(lesson);
+    testsState = textsAndTestsArr.reduce((acc, curr, i) => {
+      return [
+        ...acc,
+        {
+          passed: false,
+          testText: curr[0],
+          testId: i,
+          isLoading: !project.blockingTests
+        }
+      ];
+    }, []);
+
+    updateTests(ws, testsState);
+    updateConsole(ws, '');
+
+    // Create one worker for each test if non-blocking.
+    // TODO: See if holding pool of workers is better.
+    if (project.blockingTests) {
+      const worker = new Worker('./test-worker.js', {
+        name: 'blocking-worker'
+      });
+
+      // Kill worker if client says, or test timesout
+      ws.on('message', async data => {
+        const { event, data } = JSON.parse(message);
+        if (event === 'cancel-tests') {
+          worker.terminate();
+        }
+      });
+      // When result is received back from worker, update the client state
+      worker.on('message', message => {
+        const { passed, testId, testText, error } = message;
+        if (error) {
+          if (!(error instanceof AssertionError)) {
+            logover.error(`Test #${testId}:`, error);
+            updateError(ws, error);
+          }
+
+          const consoleError = {
+            ...testsState[testId],
+            error
+          };
+          updateConsole(ws, consoleError);
+        }
+        updateTest(ws, { passed, testId, testText, isLoading: false });
+      });
+
+      for (let i = 0; i < textsAndTestsArr.length; i++) {
+        const [text, testCode] = textsAndTestsArr[i];
+        testsState[i].isLoading = true;
+        updateTest(ws, testsState[i]);
+
+        if (beforeEach) {
+          try {
+            logover.debug('Starting: --before-each-- hook');
+            const _beforeEachOut = await eval(
+              `(async () => { ${beforeEach} })();`
+            );
+            logover.debug('Finished: --before-each-- hook');
+          } catch (e) {
+            logover.error('--before-each-- hook failed to run:');
+            logover.error(e);
+          }
+        }
+        worker.postMessage({ testCode, testId: i });
+      }
+    } else {
+      // Run tests in parallel, and in own worker threads
+      for (let i = 0; i < textsAndTestsArr.length; i++) {
+        const [text, testCode] = textsAndTestsArr[i];
+        testsState[i].isLoading = true;
+        updateTest(ws, testsState[i]);
+
+        if (beforeEach) {
+          try {
+            logover.debug('Starting: --before-each-- hook');
+            const _beforeEachOut = await eval(
+              `(async () => { ${beforeEach} })();`
+            );
+            logover.debug('Finished: --before-each-- hook');
+          } catch (e) {
+            logover.error('--before-each-- hook failed to run:');
+            logover.error(e);
+          }
+        }
+
+        const worker = new Worker('./test-worker.js', {
+          name: `worker-${i}`
+        });
+
+        // Kill worker if client says, or test timesout
+        ws.on('message', async data => {
+          const { event, data } = JSON.parse(message);
+          if (event === 'cancel-tests') {
+            worker.terminate();
+          }
+        });
+        // When result is received back from worker, update the client state
+        worker.on('message', message => {
+          const { passed, testId, error } = message;
+          if (error) {
+            if (!(error instanceof AssertionError)) {
+              logover.error(`Test #${testId}:`, error);
+              updateError(ws, error);
+            }
+
+            const consoleError = {
+              ...testsState[testId],
+              error
+            };
+            updateConsole(ws, consoleError);
+          }
+          updateTest(ws, {
+            passed,
+            testId,
+            testText: testsState[testId].testText
+          });
+        });
+
+        worker.postMessage({ testCode, testId: i });
+      }
+    }
+
+    // Run afterAll hook
+    if (afterAll) {
+      try {
+        logover.debug('Starting: --after-all-- hook');
+        await eval(`(async () => {${afterAll}})()`);
+        logover.debug('Finished: --after-all-- hook');
+      } catch (e) {
+        logover.error('--after-all-- hook failed to run:');
+        logover.error(e);
+      }
+    }
+  } catch (e) {}
+}
+
+async function testPassedCallback(testId) {
+  if (passed) {
+    if (project.isIntegrated || lessonNumber === project.numberOfLessons - 1) {
+      await setProjectConfig(project.dashedName, {
+        completedDate: Date.now()
+      });
+      resetBottomPanel(ws);
+      handleProjectFinish(ws);
+    } else {
+      await setProjectConfig(project.dashedName, {
+        currentLesson: lessonNumber + 1
+      });
+      await runLesson(ws, projectDashedName);
+    }
+  } else {
+    updateHints(ws, hints);
+  }
+}

--- a/.freeCodeCamp/tooling/tests/test-worker.js
+++ b/.freeCodeCamp/tooling/tests/test-worker.js
@@ -23,11 +23,16 @@ parentPort.on('message', async ({ testCode, testId }) => {
   let passed = false;
   let error = null;
   try {
-    const _beforeEachOut = await eval(`(async () => { ${beforeEach} })();`);
-    const _testOutput = await eval(`(async () => {${testCode}})();`);
+    const _eval_out = await eval(`(async () => {
+      ${beforeEach}
+      ${testCode}
+})();`);
     passed = true;
   } catch (e) {
-    error = e;
+    error = {};
+    error.text = e;
+    // Cannot pass `e` "as is", because classes cannot be passed between threads
+    error.type = e instanceof AssertionError ? 'AssertionError' : 'Error';
   }
   parentPort.postMessage({ passed, testId, error });
 });

--- a/.freeCodeCamp/tooling/tests/test-worker.js
+++ b/.freeCodeCamp/tooling/tests/test-worker.js
@@ -1,4 +1,4 @@
-import { parentPort } from 'node:worker_threads';
+import { parentPort, workerData } from 'node:worker_threads';
 // These are used in the local scope of the `eval` in `runTests`
 import { assert, AssertionError, expect, config as chaiConfig } from 'chai';
 import __helpers_c from '../test-utils.js';
@@ -17,14 +17,13 @@ if (helpers) {
   __helpers = { ...__helpers_c, ...dynamicHelpers };
 }
 
-// Needs testString to run eval
-// Needs globals to run eval
-// Sends back: { passed, testId, error }
+const { beforeEach = '' } = workerData;
 
 parentPort.on('message', async ({ testCode, testId }) => {
   let passed = false;
   let error = null;
   try {
+    const _beforeEachOut = await eval(`(async () => { ${beforeEach} })();`);
     const _testOutput = await eval(`(async () => {${testCode}})();`);
     passed = true;
   } catch (e) {

--- a/.freeCodeCamp/tooling/tests/test-worker.js
+++ b/.freeCodeCamp/tooling/tests/test-worker.js
@@ -1,37 +1,12 @@
 import { parentPort } from 'node:worker_threads';
 // These are used in the local scope of the `eval` in `runTests`
 import { assert, AssertionError, expect, config as chaiConfig } from 'chai';
-import __helpers_c from './test-utils.js';
-import { watcher } from './hot-reload.js';
+import __helpers_c from '../test-utils.js';
+import { watcher } from '../hot-reload.js';
 
-import {
-  getLessonTextsAndTests,
-  getLessonFromFile,
-  getBeforeAll,
-  getBeforeEach,
-  getAfterAll,
-  getLessonHints
-} from './parser.js';
-
-import {
-  freeCodeCampConfig,
-  getProjectConfig,
-  getState,
-  ROOT,
-  setProjectConfig
-} from './env.js';
-import {
-  toggleLoaderAnimation,
-  updateTest,
-  updateTests,
-  updateConsole,
-  updateHints,
-  handleProjectFinish,
-  resetBottomPanel
-} from './client-socks.js';
+import { freeCodeCampConfig, ROOT } from '../env.js';
 import { join } from 'path';
-import { logover } from './logger.js';
-import { Worker } from 'node:worker_threads';
+import { logover } from '../logger.js';
 
 let __helpers = __helpers_c;
 
@@ -47,6 +22,13 @@ if (helpers) {
 // Sends back: { passed, testId, error }
 
 parentPort.on('message', async ({ testCode, testId }) => {
-  const _testOutput = await eval(`(async () => {${testCode}})();`);
-  return { passed, testId, error };
+  let passed = false;
+  let error = null;
+  try {
+    const _testOutput = await eval(`(async () => {${testCode}})();`);
+    passed = true;
+  } catch (e) {
+    error = e;
+  }
+  parentPort.postMessage({ passed, testId, error });
 });

--- a/.freeCodeCamp/tooling/tests/test-worker.js
+++ b/.freeCodeCamp/tooling/tests/test-worker.js
@@ -1,0 +1,52 @@
+import { parentPort } from 'node:worker_threads';
+// These are used in the local scope of the `eval` in `runTests`
+import { assert, AssertionError, expect, config as chaiConfig } from 'chai';
+import __helpers_c from './test-utils.js';
+import { watcher } from './hot-reload.js';
+
+import {
+  getLessonTextsAndTests,
+  getLessonFromFile,
+  getBeforeAll,
+  getBeforeEach,
+  getAfterAll,
+  getLessonHints
+} from './parser.js';
+
+import {
+  freeCodeCampConfig,
+  getProjectConfig,
+  getState,
+  ROOT,
+  setProjectConfig
+} from './env.js';
+import {
+  toggleLoaderAnimation,
+  updateTest,
+  updateTests,
+  updateConsole,
+  updateHints,
+  handleProjectFinish,
+  resetBottomPanel
+} from './client-socks.js';
+import { join } from 'path';
+import { logover } from './logger.js';
+import { Worker } from 'node:worker_threads';
+
+let __helpers = __helpers_c;
+
+// Update __helpers with dynamic utils:
+const helpers = freeCodeCampConfig.tooling?.['helpers'];
+if (helpers) {
+  const dynamicHelpers = await import(join(ROOT, helpers));
+  __helpers = { ...__helpers_c, ...dynamicHelpers };
+}
+
+// Needs testString to run eval
+// Needs globals to run eval
+// Sends back: { passed, testId, error }
+
+parentPort.on('message', async ({ testCode, testId }) => {
+  const _testOutput = await eval(`(async () => {${testCode}})();`);
+  return { passed, testId, error };
+});

--- a/curriculum/locales/english/build-x-using-y.md
+++ b/curriculum/locales/english/build-x-using-y.md
@@ -41,19 +41,35 @@ Dynamic helpers should be imported.
 // 2
 await new Promise(resolve => setTimeout(resolve, 1000));
 assert.equal(__helpers.testDynamicHelper(), 'Helper success!');
+// assert.fail('test');
+```
+
+### --before-each--
+
+```js
+await new Promise(resolve => setTimeout(resolve, 1000));
+const __projectLoc = 'example global variable for tests';
+```
+
+### --after-each--
+
+```js
+await new Promise(resolve => setTimeout(resolve, 1000));
+logover.info('after each');
 ```
 
 ### --before-all--
 
 ```js
-global.__projectLoc = 'example global variable for tests';
+await new Promise(resolve => setTimeout(resolve, 1000));
+logover.info('before all');
 ```
 
 ### --after-all--
 
 ```js
-// Clean up
-delete global.__projectLoc;
+await new Promise(resolve => setTimeout(resolve, 1000));
+logover.info('after all');
 ```
 
 ## --fcc-end--

--- a/curriculum/locales/english/learn-freecodecamp-os.md
+++ b/curriculum/locales/english/learn-freecodecamp-os.md
@@ -38,6 +38,7 @@ Click the `Run Tests` button again. Then, click the `Console` tab in the bottom 
 This is a test that will always fail.
 
 ```js
+await new Promise(resolve => setTimeout(resolve, 5000));
 assert.fail(
   'This is a custom test assertion message. Click the > button to go to the next lesson'
 );
@@ -63,13 +64,23 @@ const file = await readFile(
   'curriculum/locales/english/learn-freecodecamp-os.md',
   'utf-8'
 );
+await new Promise(resolve => setTimeout(resolve, 5000));
 assert.notInclude(file.slice(0, 100), 'Welcome to freeCodeCampOS!');
 ```
 
 I always fail 🙃
 
 ```js
+await new Promise(resolve => setTimeout(resolve, 3000));
+console.log('Look! Worker stdout is printed in debug mode: ', __a);
+assert(__a == 1);
 assert.fail('Click the > button to go to the next lesson');
+```
+
+### --before-each--
+
+```js
+const __a = 1;
 ```
 
 ## 3
@@ -271,7 +282,7 @@ The `id` property should be `0`.
 assert.equal(__projects[0].id, 0);
 ```
 
-### --defore-all--
+### --before-each--
 
 ```js
 const { readFile } = await import('fs/promises');
@@ -280,13 +291,6 @@ const file = await readFile(
   'utf-8'
 );
 const __projects = JSON.parse(file);
-global.__projects = __projects;
-```
-
-### --after-all--
-
-```js
-delete global.__projects;
 ```
 
 ## 10
@@ -651,7 +655,7 @@ The `<LOCALE_DIR>` property should be a string.
 assert.isString(__conf.curriculum.locales['<LOCALE_DIR>']);
 ```
 
-### --before-all--
+### --before-each--
 
 ```js
 const { readFile } = await import('fs/promises');
@@ -660,13 +664,6 @@ const conf = await readFile(
   'utf-8'
 );
 const __conf = JSON.parse(conf);
-global.__conf = __conf;
-```
-
-### --after-all--
-
-```js
-delete global.__conf;
 ```
 
 ## 18
@@ -926,7 +923,7 @@ The `runTestsOnWatch` property should have a value of `true`.
 assert.isTrue(__projects[0].runTestsOnWatch);
 ```
 
-### --before-all--
+### --before-each--
 
 ```js
 const { readFile } = await import('fs/promises');
@@ -935,13 +932,6 @@ const file = await readFile(
   'utf-8'
 );
 const __projects = JSON.parse(file);
-global.__projects = __projects;
-```
-
-### --after-all--
-
-```js
-delete global.__projects;
 ```
 
 ## 26

--- a/docs/src/CHANGELOG.md
+++ b/docs/src/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
-## [2.0.0] - UNRELEASED
+## [2.1.0] - 2023-12-XX
+
+### Add
+
+- Worker threads to run tests in parallel
+- `### --after-each--` to run code after each test
+- `Cancel Tests` button that terminates all workers
+
+### Update
+
+- dependency @types/node to v18.18.13
+- dependency @types/react-dom to v18.2.17
+- dependency typescript to v5.3.2
+- dependency ts-loader to v9.5.1
+- dependency marked-highlight to v2.0.7
+- dependency marked to v9.1.6
+- babel monorepo to v7.23.3
+- dependency @types/prismjs to v1.26.3
+- dependency @types/react to v18.2.36
+- actions/setup-node digest to 1a4442c (#380)
+- dependency chai to v4.3.10
+- dependency @types/marked to v5.0.2
+
+## [2.0.0] - 2023-09-25
 
 ### Add
 
@@ -39,8 +62,6 @@
 2. Change all lesson numbers to be zero-based (start at `0`)
 3. Manually build client before running tooling server (`npm run build:client`)
    1. **Suggestion:** Add `cd ./node_modules/@freecodecamp/freecodecamp-os/ && npm run build:client` to `freecodecamp.conf.json > prepare`
-
-## [1.8.5] - UNRELEASED
 
 ## [1.10.0] - 2023-08-08
 

--- a/docs/src/CHANGELOG.md
+++ b/docs/src/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.1.0] - 2023-12-XX
+## [2.1.0] - 2023-12-12
 
 ### Add
 
@@ -23,7 +23,7 @@
 - dependency chai to v4.3.10
 - dependency @types/marked to v5.0.2
 
-## [2.0.0] - 2023-09-25
+## [2.0.0 - deprecated] - 2023-09-25
 
 ### Add
 
@@ -47,6 +47,7 @@
 - remove landing page topic (`h2`)
 - `config.path` is no longer required
 - Remove `postinstall` script
+- Tests no longer have `--before-all--` context
 
 ### Update
 
@@ -62,6 +63,9 @@
 2. Change all lesson numbers to be zero-based (start at `0`)
 3. Manually build client before running tooling server (`npm run build:client`)
    1. **Suggestion:** Add `cd ./node_modules/@freecodecamp/freecodecamp-os/ && npm run build:client` to `freecodecamp.conf.json > prepare`
+4. Change `--before-all--` into `--before-each--`
+   1. Probably remove `--after-all--`
+   2. No longer use `global` in tests
 
 ## [1.10.0] - 2023-08-08
 

--- a/docs/src/testing/globals.md
+++ b/docs/src/testing/globals.md
@@ -47,4 +47,4 @@ watcher.add(DIRECTORY_PATH_RELATIVE_TO_ROOT);
 
 ## Collisions
 
-As the tests are run in the `eval`ed context of the `freecodecamp-os/.freeCodeCamp/tooling/test.js` module, there is the possibility that variable naming collisions will occur. To avoid this, it is recommended to prefix object names with `__` (dunder).
+As the tests are run in the `eval`ed context of the `freecodecamp-os/.freeCodeCamp/tooling/tests/test-worker.js` module, there is the possibility that variable naming collisions will occur. To avoid this, it is recommended to prefix object names with `__` (dunder).

--- a/docs/src/testing/lifecycle.md
+++ b/docs/src/testing/lifecycle.md
@@ -6,9 +6,13 @@ The lifecycle of the testing system follows:
 2. Server evaluates any `--before-all--` ops
 
 - If any `--before-all--` ops fail, an error is printed to the console
-- If any `--before-all--` ops fail, the tests **continue** to run
+- If any `--before-all--` ops fail, the tests stop running
 
-3. Server evaluates all tests asynchronously[^1]
+3. Server evaluates all tests in parallel[^1]
+   1. Server evaluates any `--before-each--` ops
+      1. If any `--before-each--` ops fail, test code is not run
+   2. Server evaluates the test
+   3. Server evaluates any `--after-each--` ops
 4. Server evaluates any `--after-all--` ops
 
 - If any `--after-all--` ops fail, an error is printed to the console

--- a/docs/src/testing/test.md
+++ b/docs/src/testing/test.md
@@ -1,5 +1,9 @@
 # Test
 
-```admonish todo
+Tests are run in worker threads. For non-blocking tests, each test is run in its own worker[^1]. For blocking tests, all tests are run in the same worker - one after the other.
 
+```admonish attention
+The `--before-all--`, `--after-each`, and `--after-all--` context is only available in the main thread.
 ```
+
+[^1]: The operating system decides how many threads may be concurrent.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freecodecamp/freecodecamp-os",
   "author": "freeCodeCamp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Package used for freeCodeCamp projects with the freeCodeCamp Courses VSCode extension",
   "scripts": {
     "build:client": "FCC_OS_PORT=8081 NODE_ENV=production webpack --config ./.freeCodeCamp/webpack.config.cjs",


### PR DESCRIPTION
Moves test logic into the `Worker` API to allow for cancellable tests.

`2.0` is deprecated, as it is "as of yet" unused, and `2.1` changes added to `2.0` migration.

Closes #232 