### PR TITLE
fix: pathing and npmignore

### DIFF
--- a/.freeCodeCamp/tooling/t.js
+++ b/.freeCodeCamp/tooling/t.js
@@ -1,4 +1,5 @@
-import { getState } from './env.js';
+import { join } from 'path';
+import { ROOT, getState } from './env.js';
 
 export async function t(key, args = {}, forceLangToUse) {
   const { locale: loc } = await getState();
@@ -7,7 +8,11 @@ export async function t(key, args = {}, forceLangToUse) {
   const locale = forceLangToUse ?? loc;
   // TODO: Not used anywhere, but needs path fixing too.
   const comments = import(
-    `.freeCodeCamp/tooling/locales/${locale}/comments.json`,
+    join(
+      ROOT,
+      'node_modules/@freecodecamp/freecodecamp-os',
+      `.freeCodeCamp/tooling/locales/${locale}/comments.json`
+    ),
     {
       assert: { type: 'json' }
     }

--- a/.freeCodeCamp/tooling/tests/main.js
+++ b/.freeCodeCamp/tooling/tests/main.js
@@ -345,7 +345,12 @@ async function handleWorkerExit({ ws, exitCode, testsState, i, afterEach }) {
 
 function createWorker(name, workerData) {
   return new Worker(
-    join(ROOT, '.freeCodeCamp/tooling/tests', 'test-worker.js'),
+    join(
+      ROOT,
+      'node_modules/@freecodecamp/freecodecamp-os',
+      '.freeCodeCamp/tooling/tests',
+      'test-worker.js'
+    ),
     {
       name,
       workerData,

--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@ build-x-using-y
 config
 curriculum
 docs
-learn-x-by-building-y
+learn-freecodecamp-os
 /tooling
 .editorconfig
 .gitignore


### PR DESCRIPTION
A lot of these were missed, because the local development within the package itself does not need the full import paths