### PR TITLE
feat: injectable script

### DIFF
--- a/.freeCodeCamp/client/index.html
+++ b/.freeCodeCamp/client/index.html
@@ -3,9 +3,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <title>freeCodeCamp: Course</title>
+    <title>freeCodeCamp: Courses</title>
+    <script defer src="/script/injectable.js"></script>
   </head>
-
   <body>
     <div id="root"></div>
   </body>

--- a/docs/src/CHANGELOG.md
+++ b/docs/src/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.1.0] - 2024-01-19
+## [2.1.0] - 2024-01-23
 
 ### Add
 
@@ -14,6 +14,8 @@
   - `onLessonPassed`
   - `onLessonFailed`
   - `onProjectFinished`
+- `/script/injectable.js` static file to inject a JS script into the client
+- `__run-client-code` websocket event to run code in the server's context
 
 ### Update
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,7 @@
   - [Lifecycle](./resetting/lifecycle.md)
   - [Reset](./resetting/reset.md)
 - [Plugin System](./plugin-system.md)
+- [Client Injection](./client-injection.md)
 - [Contributing](./contributing.md)
 - [CHANGELOG](./CHANGELOG.md)
 - [Roadmap](./roadmap.md)

--- a/docs/src/client-injection.md
+++ b/docs/src/client-injection.md
@@ -1,0 +1,120 @@
+# Client Injection
+
+With the [`static` config](./configuration.md#client) option, you can add a `/script/injectable.js` script to be injected in the `head` of the client.
+
+````admonish example
+```json
+{
+  "client": {
+    "static": {
+      "/script/injectable.js": "./client/injectable.js"
+    }
+  }
+}
+```
+````
+
+There is a reserved websocket event (`__run-client-code`) that can be used to send code from the client to the server to be run in the server's context. The code has access to a few globals:
+
+- `ROOT`: The root of the course
+- `join`: The Node.js `path` module function
+
+This enables scripts like the following to be run:
+
+````admonish example collapsible=true title="client/injectable.js"
+```js
+function checkForToken() {
+  const serverTokenCode = `
+    try {
+      const {readFile} = await import('fs/promises');
+      const tokenFile = await readFile(join(ROOT, 'config/token.txt'));
+      const token = tokenFile.toString();
+      console.log(token);
+      __result = token;
+    } catch (e) {
+      console.error(e);
+      __result = null;
+    }`;
+  socket.send(
+    JSON.stringify({
+      event: '__run-client-code',
+      data: serverTokenCode
+    })
+  );
+}
+
+async function askForToken() {
+  const modal = document.createElement('dialog');
+  const p = document.createElement('p');
+  p.innerText = 'Enter your token';
+  p.style.color = 'black';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.id = 'token-input';
+  input.style.color = 'black';
+  const button = document.createElement('button');
+  button.innerText = 'Submit';
+  button.style.color = 'black';
+  button.onclick = async () => {
+    const token = input.value;
+    const serverTokenCode = `
+      try {
+        const {writeFile} = await import('fs/promises');
+        await writeFile(join(ROOT, 'config/token.txt'), '${token}');
+        __result = true;
+      } catch (e) {
+        console.error(e);
+        __result = false;
+      }`;
+    socket.send(
+      JSON.stringify({
+        event: '__run-client-code',
+        data: serverTokenCode
+      })
+    );
+    modal.close();
+  };
+
+  modal.appendChild(p);
+  modal.appendChild(input);
+  modal.appendChild(button);
+  document.body.appendChild(modal);
+  modal.showModal();
+}
+
+const socket = new WebSocket(
+  `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${
+    window.location.host
+  }`
+);
+
+window.onload = function () {
+  socket.onmessage = function (event) {
+    const parsedData = JSON.parse(event.data);
+    if (
+      parsedData.event === 'RESPONSE' &&
+      parsedData.data.event === '__run-client-code'
+    ) {
+      if (parsedData.data.error) {
+        console.log(parsedData.data.error);
+        return;
+      }
+      const { __result } = parsedData.data;
+      if (!__result) {
+        askForToken();
+        return;
+      }
+      window.__token = __result;
+    }
+  };
+  let interval;
+  interval = setInterval(() => {
+    if (socket.readyState === 1) {
+      clearInterval(interval);
+      checkForToken();
+    }
+  }, 1000);
+};
+
+```
+````

--- a/self/client/injectable.js
+++ b/self/client/injectable.js
@@ -1,0 +1,1 @@
+console.log(document);

--- a/self/client/injectable.js
+++ b/self/client/injectable.js
@@ -1,1 +1,92 @@
-console.log(document);
+function checkForToken() {
+  const serverTokenCode = `
+    try {
+      const {readFile} = await import('fs/promises');
+      const tokenFile = await readFile(join(ROOT, 'config/token.txt'));
+      const token = tokenFile.toString();
+      console.log(token);
+      __result = token;
+    } catch (e) {
+      console.error(e);
+      __result = null;
+    }`;
+  socket.send(
+    JSON.stringify({
+      event: '__run-client-code',
+      data: serverTokenCode
+    })
+  );
+}
+
+async function askForToken() {
+  const modal = document.createElement('dialog');
+  const p = document.createElement('p');
+  p.innerText = 'Enter your token';
+  p.style.color = 'black';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.id = 'token-input';
+  input.style.color = 'black';
+  const button = document.createElement('button');
+  button.innerText = 'Submit';
+  button.style.color = 'black';
+  button.onclick = async () => {
+    const token = input.value;
+    const serverTokenCode = `
+      try {
+        const {writeFile} = await import('fs/promises');
+        await writeFile(join(ROOT, 'config/token.txt'), '${token}');
+        __result = true;
+      } catch (e) {
+        console.error(e);
+        __result = false;
+      }`;
+    socket.send(
+      JSON.stringify({
+        event: '__run-client-code',
+        data: serverTokenCode
+      })
+    );
+    modal.close();
+  };
+
+  modal.appendChild(p);
+  modal.appendChild(input);
+  modal.appendChild(button);
+  document.body.appendChild(modal);
+  modal.showModal();
+}
+
+const socket = new WebSocket(
+  `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${
+    window.location.host
+  }`
+);
+
+window.onload = function () {
+  socket.onmessage = function (event) {
+    const parsedData = JSON.parse(event.data);
+    if (
+      parsedData.event === 'RESPONSE' &&
+      parsedData.data.event === '__run-client-code'
+    ) {
+      if (parsedData.data.error) {
+        console.log(parsedData.data.error);
+        return;
+      }
+      const { __result } = parsedData.data;
+      if (!__result) {
+        askForToken();
+        return;
+      }
+      window.__token = __result;
+    }
+  };
+  let interval;
+  interval = setInterval(() => {
+    if (socket.readyState === 1) {
+      clearInterval(interval);
+      checkForToken();
+    }
+  }, 1000);
+};

--- a/self/freecodecamp.conf.json
+++ b/self/freecodecamp.conf.json
@@ -41,7 +41,8 @@
       "faq-text": "Link to FAQ related to course"
     },
     "static": {
-      "/images": "./curriculum/images"
+      "/images": "./curriculum/images",
+      "/script/injectable.js": "./client/injectable.js"
     }
   },
   "config": {


### PR DESCRIPTION
Closes: https://github.com/freeCodeCamp/freeCodeCampOS/issues/441

<img width="615" alt="image" src="https://github.com/freeCodeCamp/freeCodeCampOS/assets/51722130/bdd7d7fc-f3a3-4153-8f21-d5012846f8fd">

Without the script being defined, an error is thrown to the console, but the app continues to function as expected. Maybe there is a better way to default the missing script, but, for now, at least there is no impact.